### PR TITLE
Fixed Django 1.9 escaping & conditional embedding of the JS template tag

### DIFF
--- a/phrase/templatetags/phrase_i18n.py
+++ b/phrase/templatetags/phrase_i18n.py
@@ -172,6 +172,7 @@ def phrase_javascript():
     (function() {
     var phraseapp = document.createElement('script');
     phraseapp.type = 'text/javascript';
+    phraseapp.autoLowercase = false;
     phraseapp.async = true;
     phraseapp.src = ['%(protocol)s', '%(host)s/assets/in-context-editor/2.0/app.js?', new Date().getTime()].join('');
     var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(phraseapp, s); \

--- a/phrase/templatetags/phrase_i18n.py
+++ b/phrase/templatetags/phrase_i18n.py
@@ -168,14 +168,16 @@ def phrase_javascript():
     if not phrase_settings.PHRASE_ENABLED:
         return ''
     html = """<script>
-    window.PHRASEAPP_CONFIG = { projectId: '%(project_id)s' };
+    window.PHRASEAPP_CONFIG = {
+        projectId: '%(project_id)s',
+        autoLowercase :false,
+        };
     (function() {
-    var phraseapp = document.createElement('script');
-    phraseapp.type = 'text/javascript';
-    phraseapp.autoLowercase = false;
-    phraseapp.async = true;
-    phraseapp.src = ['%(protocol)s', '%(host)s/assets/in-context-editor/2.0/app.js?', new Date().getTime()].join('');
-    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(phraseapp, s); \
+    var phrasejs = document.createElement('script');
+    phrasejs.type = 'text/javascript';
+    phrasejs.async = true;
+    phrasejs.src = ['%(protocol)s', '%(host)s/assets/in-context-editor/2.0/app.js?', new Date().getTime()].join('');
+    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(phrasejs, s); \
     })();
     </script>"""
     formatted_html = html % dict(


### PR DESCRIPTION
[As of Django 1.9](https://docs.djangoproject.com/en/1.9/howto/custom-template-tags/#django.template.Library.simple_tag), `simple_tag` has auto-escaping and requires to be marked as safe to avoid being escaped

I also fixed a bug where the JS snippet would be loaded & displayed even when Phrase isn't explicitly enabled in settings