### PR TITLE
py36 support: add support for python3 str and python2 unicode

### DIFF
--- a/phrase/utils.py
+++ b/phrase/utils.py
@@ -1,5 +1,6 @@
 from phrase import settings as phrase_settings
 from django.utils.encoding import python_2_unicode_compatible
+from django.utils.six import text_type
 
 import logging
 
@@ -28,9 +29,7 @@ class PhraseDelegate:
         return name
 
     def __safer_name(self):
-        if type(self.name) is unicode:
-          return str(self.name)
-        elif type(self.name) is str:
-          return str(self.name)
+        if type(self.name) is text_type:
+          return text_type(self.name)
         else:
-          return str(self.name.literal)
+          return text_type(self.name.literal)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 
 setup(
     name='django-phrase',
-    version='1.0.6',
+    version='1.0.7',
     description='Connect your Django apps to PhraseApp, the powerful in-context-translation solution.',
     long_description=open('README.rst').read(),
     author='Dynport GmbH',


### PR DESCRIPTION
Background: Problem is that python 2.7 has a different type for string objects. In `2.7` we use `unicode`, in python `3.6` we use `str`. Some more detail on this: https://consideratecode.com/2017/08/25/what-does-python_2_unicode_compatible-do/