### PR TITLE
chore: adjust CODEOWNERS to team level

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Varpusparvi @francawinter @itsahsiao @lookasc @flowreaction @valeraine
+* @phrase/strings-editor


### PR DESCRIPTION
To adjust CODEOWNERS to team level rather than individuals